### PR TITLE
Fix for start-up crashes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,23 @@ namespace AmpShell
         [STAThread]
         private static void Main(string[] args)
         {
+            Application.SetCompatibleTextRenderingDefault(false);
+
+            //The thread exception handler has to be assigned before any control is presented on the screen.
+            if (args is null || args.Any() == false)
+            {
+                // Add the event handler for handling UI thread exceptions to the event.
+                Application.ThreadException += new ThreadExceptionEventHandler(UIThreadExceptionMethod);
+
+                // Set the unhandled exception mode to force all Windows Forms errors to go through
+                // our handler.
+                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+
+                // Add the event handler for handling non-UI thread exceptions to the event.
+                AppDomain.CurrentDomain.UnhandledException +=
+                    new UnhandledExceptionEventHandler(CurrentDomainUnhandledExceptionMethod);
+            }
+
             UserDataAccessor.LoadUserSettingsAndRunAutoConfig();
 
             if (UserDataAccessor.UserData.GamesUseDOSBox && StringExt.IsNullOrWhiteSpace(UserDataAccessor.UserData.DBPath) && IsWindows98())
@@ -80,16 +97,6 @@ namespace AmpShell
             }
             if (args is null || args.Any() == false)
             {
-                // Add the event handler for handling UI thread exceptions to the event.
-                Application.ThreadException += new ThreadExceptionEventHandler(UIThreadExceptionMethod);
-
-                // Set the unhandled exception mode to force all Windows Forms errors to go through
-                // our handler.
-                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
-
-                // Add the event handler for handling non-UI thread exceptions to the event.
-                AppDomain.CurrentDomain.UnhandledException +=
-                    new UnhandledExceptionEventHandler(CurrentDomainUnhandledExceptionMethod);
                 RunMainForm();
             }
             else
@@ -171,7 +178,7 @@ namespace AmpShell
             {
                 Application.EnableVisualStyles();
             }
-            Application.SetCompatibleTextRenderingDefault(false);
+
             var mainForm = new MainForm();
             using (mainForm)
             {


### PR DESCRIPTION
Fixes start-up crashes due to displaying the open file dialog prior to calling some routines which do not support to be fired after a control is added to the form.

Once you choose Yes a control is created.
![nqcP9t4jic](https://user-images.githubusercontent.com/25939765/119394745-ef490600-bca8-11eb-8888-6805f20f4cb3.jpg)

And you can't call this anymore, nor you can call "Application.SetCompatibleTextRenderingDefault(false);".
![939co0LMNo](https://user-images.githubusercontent.com/25939765/119394767-f6701400-bca8-11eb-9425-0ec009f373d0.jpg)